### PR TITLE
Replace use of utils/get-node-extip with an environment variable

### DIFF
--- a/content/exercise/00-setup/index.md
+++ b/content/exercise/00-setup/index.md
@@ -11,17 +11,17 @@ weight = 1
 +++
 
 To complete the exercises, you'll need:
-* a Kubernetes cluster, and
-* a command-line terminal with the [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/) client.
+- a Kubernetes cluster, and
+- a command-line terminal with the [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/) client.
 
 ### Get a cluster
 If you're completing these exercises on your own, you'll need to provide your own cluster.
 Here are a few ways to get a cluster running:
-* Install [Docker for Mac](https://docs.docker.com/docker-for-mac/) or [Docker for Windows](https://docs.docker.com/docker-for-windows/) and enable Kubernetes.
-  * On Windows, keep the default setting so you can run Linux containers. [Switch back to Linux](https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers) if you currently use Windows containers.
-* Install [Minikube](https://kubernetes.io/docs/setup/learning-environment/minikube/).
-* [Create a cluster in Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/docs/quickstart) or a similar managed Kubernetes service.
-* Use another tool to create a cluster.
+- Install [Docker for Mac](https://docs.docker.com/docker-for-mac/) or [Docker for Windows](https://docs.docker.com/docker-for-windows/) and enable Kubernetes.
+  - On Windows, keep the default setting so you can run Linux containers. [Switch back to Linux](https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers) if you currently use Windows containers.
+- Install [Minikube](https://kubernetes.io/docs/setup/learning-environment/minikube/).
+- [Create a cluster in Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/docs/quickstart) or a similar managed Kubernetes service.
+- Use another tool to create a cluster.
 
 You can do all the exercises with a CPU core or two; one node should work fine.
 
@@ -61,6 +61,43 @@ These exercises intentionally introduce vulnerable services into your cluster.
 You can see the materials for each exercise on the site, and the `kubectl` commands download files straight from the site so you don't need to have them on your machine.
 
 However, if you do clone [the GitHub repository](https://github.com/stackrox/bsidessf-2020-workshop) for this site, you'll get a few extra scripts and you'll be able to view files in your own editor instead of your browser.
+
+### Set your node IP
+To complete the exercises without modifying them yourself, you'll need to be able to access your cluster by using [**NodePort**](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) services.
+
+The exercises use hardcoded NodePort numbers for simplicity.
+If you're running other applications in your cluster, or you've customized your [NodePort range](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport), you may need to modify the examples.
+
+The examples use a variable, `WORKSHOP_NODE_IP`, that defaults to `localhost`.
+
+ - If you're using a local setup like Docker for Mac, `localhost` should work.
+ - If you're using a different type of cluster, you may have to set a value for `WORKSHOP_NODE_IP`.
+
+```bash
+export WORKSHOP_NODE_IP="<your-ip-or-hostname>"
+```
+
+#### "Smoke test"
+Use the smoke-test deploy to make sure you can access services.
+If you can't access the smoke-test, the server-based deploys probably won't work, though you can follow along with most of the other exercises.
+
+```bash
+kubectl create -f https://securek8s.dev/smoke-test/deploy.yaml
+```
+
+You should be able to see the "Welcome to nginx!" page on port 30000 on your `WORKSHOP_NODE_IP`:
+
+```bash
+open "http://${WORKSHOP_NODE_IP:-localhost}:30000"
+```
+
+If this doesn't work, check the output of `kubectl describe node` or:
+```
+kubectl get node -o wide
+```
+to see if other listed IPs or hostnames work.
+
+If you're running in a cloud, you'll usually need to add a firewall rule that allows traffic to the NodePort range (at least ports 30000-30005 for these examples) on your cluster nodes.
 
 ### Next up
 Get started!

--- a/content/exercise/01-streamline-image/index.md
+++ b/content/exercise/01-streamline-image/index.md
@@ -55,7 +55,7 @@ Use a canned exploit that launches a shell, downloads a cryptominer,
 and runs it.
 
 ```
-static/struts/attack.sh struts "$(./utils/get-node-extip):30003"
+static/struts/attack.sh struts "${WORKSHOP_NODE_IP:-localhost}:30003"
 ```
 
 (If you haven't cloned the workshop repository, {{< downloadLink file="/static/struts/attack.sh" prompt="download the attack script" >}}, make it executable by running `chmod +x attack.sh`, then run it.)
@@ -102,7 +102,7 @@ and the older pod is `Terminating`.
 Then we'll attack the new one:
 
 ```bash
-static/struts/attack.sh struts "$(./utils/get-node-extip):30003"
+static/struts/attack.sh struts "${WORKSHOP_NODE_IP:-localhost}:30003"
 ```
 
 You'll see an error from the same injected command we ran earlier:

--- a/content/exercise/10-ro-fs/index.md
+++ b/content/exercise/10-ro-fs/index.md
@@ -43,7 +43,7 @@ You're ready to move on once your pod is marked `Running`.
 ### Attack
 
 ```bash
-static/struts/attack.sh struts "$(./utils/get-node-extip):30003"
+static/struts/attack.sh struts "${WORKSHOP_NODE_IP:-localhost}:30003"
 ```
 
 (If you haven't cloned the workshop repository, {{< downloadLink file="/static/struts/attack.sh" prompt="download the attack script" >}}, make it executable by running `chmod +x attack.sh`, then run it.)
@@ -95,7 +95,7 @@ and the older pod is `Terminating`.
 Then we'll attack the new one:
 
 ```bash
-static/struts/attack.sh struts "$(./utils/get-node-extip):30003"
+static/struts/attack.sh struts "${WORKSHOP_NODE_IP:-localhost}:30003"
 ```
 
 You'll see an error because we can't download the cryptominer code:

--- a/content/exercise/20-netpol/index.md
+++ b/content/exercise/20-netpol/index.md
@@ -50,15 +50,13 @@ Then, let's deploy:
 kubectl apply -f https://securek8s.dev/ssrf/base.yaml
 ```
 
-The service is deployed on a NodePort on port 30001.
-
-Find an IP of one of your nodes to try it out:
+The service is deployed on a NodePort on port 30001. Open it in your browser by running:
 
 ```
-./utils/get-node-extip
+open "http://${WORKSHOP_NODE_IP:-localhost}:30001"
 ```
 
-Then open `<your ip>:30001` in a new browser tab.
+or create a new browser tab directly.
 
 ### Attack
 We'll use the fake SSRF exploit to access:

--- a/content/exercise/80-limits/index.md
+++ b/content/exercise/80-limits/index.md
@@ -60,13 +60,13 @@ kubectl apply -f https://securek8s.dev/memory-exploder/buggy.yaml
 ### "Attack"
 Call the bad method:
 ```bash
-curl -X POST http://$(utils/get-node-extip):30002/1234
+curl -X POST "http://${WORKSHOP_NODE_IP:-localhost}:30002/1234"
 ```
 
 This will work. But bump up the number and it will start getting bad!
 
 ```bash
-curl -X POST http://$(utils/get-node-extip):30002/123456789012345
+curl -X POST "http://${WORKSHOP_NODE_IP:-localhost}:30002/123456789012345"
 ```
 
 You can exit from the request and try to run:

--- a/static/smoke-test/deploy.yaml
+++ b/static/smoke-test/deploy.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: smoke-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: server
+  namespace: smoke-test
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+     labels:
+       app: nginx
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+      - image: nginx
+        name: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: smoke-test
+spec:
+  selector:
+    app: nginx
+  ports:
+    - name: https
+      protocol: TCP
+      nodePort: 30000
+      port: 30000
+      targetPort: 80
+  type: NodePort

--- a/utils/get-node-extip
+++ b/utils/get-node-extip
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -eu
-
-echo "$(kubectl get node --output=jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}')"


### PR DESCRIPTION
This avoids a dependency on GKE's networking configuration
and reduces the need to download local scripts.