### PR TITLE
Add '--' before command in kubectl execs

### DIFF
--- a/content/exercise/15-ro-mount/index.md
+++ b/content/exercise/15-ro-mount/index.md
@@ -53,7 +53,7 @@ kubectl get po -n mounts
 
 Then get into it:
 ```bash
-kubectl exec -it -n mounts $(kubectl get po -n mounts --output=jsonpath='{.items[0].metadata.name}') bash
+kubectl exec -it -n mounts "$(kubectl get po -n mounts --output=jsonpath='{.items[0].metadata.name}')" -- bash
 ```
 
 Now, try some host modifications and information gathering attempts:
@@ -149,8 +149,8 @@ kubectl get po -n mounts
 ```
 
 Then get into it:
-```
-kubectl exec -it -n mounts $(kubectl get po -n mounts --output=jsonpath='{.items[0].metadata.name}') bash
+```bash
+kubectl exec -it -n mounts "$(kubectl get po -n mounts --output=jsonpath='{.items[0].metadata.name}')" -- bash
 ```
 
 ### Attack effects after patching

--- a/content/exercise/30-sa-token/index.md
+++ b/content/exercise/30-sa-token/index.md
@@ -36,8 +36,8 @@ kubectl get po -n sa
 ```
 
 Then exec inside:
-```
-kubectl exec -it -n sa $(kubectl get po -n sa --output=jsonpath='{.items[0].metadata.name}') bash
+```bash
+kubectl exec -it -n sa "$(kubectl get po -n sa --output=jsonpath='{.items[0].metadata.name}')" -- bash
 ```
 
 ### "Attack"
@@ -105,8 +105,8 @@ kubectl get po -n sa
 ```
 
 Then exec inside:
-```
-kubectl exec -it -n sa $(kubectl get po -n sa --output=jsonpath='{.items[0].metadata.name}') bash
+```bash
+kubectl exec -it -n sa "$(kubectl get po -n sa --output=jsonpath='{.items[0].metadata.name}')" -- bash
 ```
 
 ### Attack effects after patching

--- a/content/exercise/50-ns/index.md
+++ b/content/exercise/50-ns/index.md
@@ -40,8 +40,8 @@ kubectl get pod -l app=bad-server
 ```
 
 Exec into it:
-```
-kubectl exec -it $(kubectl get po -l app=bad-server --output=jsonpath='{.items[0].metadata.name}') bash
+```bash
+kubectl exec -it "$(kubectl get po -l app=bad-server --output=jsonpath='{.items[0].metadata.name}')" -- bash
 ```
 
 Then install `curl` and note that we can reach the other service:
@@ -100,8 +100,8 @@ kubectl get pod -n bad -w
 
 ### Attack effects after patching
 Let's exec in:
-```
-kubectl exec -it -n bad $(kubectl get po -n bad -l app=bad-server --output=jsonpath='{.items[0].metadata.name}') bash
+```bash
+kubectl exec -it -n bad "$(kubectl get po -n bad -l app=bad-server --output=jsonpath='{.items[0].metadata.name}')" -- bash
 ```
 
 And then let's repeat our attempt to contact the good server:

--- a/content/exercise/60-nonroot/index.md
+++ b/content/exercise/60-nonroot/index.md
@@ -59,8 +59,8 @@ kubectl get po -n nonroot
 ```
 
 And exec into it:
-```
-kubectl exec -it -n nonroot $(kubectl get po -n nonroot --output=jsonpath='{.items[0].metadata.name}') sh
+```bash
+kubectl exec -it -n nonroot "$(kubectl get po -n nonroot --output=jsonpath='{.items[0].metadata.name}')" -- sh
 ```
 
 _Note:_ We're using `sh` now because this is an Alpine image.
@@ -135,8 +135,8 @@ You're ready to move on when your new pod (with a smaller `AGE` value) is `Runni
 and the older pod is `Terminating`.
 
 Then, you can continue trying to execute commands in the containers:
-```
-kubectl exec -it -n nonroot $(kubectl get po -n nonroot --output=jsonpath='{.items[0].metadata.name}') sh
+```bash
+kubectl exec -it -n nonroot "$(kubectl get po -n nonroot --output=jsonpath='{.items[0].metadata.name}')" -- sh
 ```
 
 Perhaps try adding new code:


### PR DESCRIPTION
`kubectl` warns that the `--` will be required in a future version:

> `kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl kubectl exec [POD] -- [COMMAND] instead.`